### PR TITLE
Add client DTD cache from ingeniux OxygenDesktopPlugin

### DIFF
--- a/assembly.xml
+++ b/assembly.xml
@@ -31,7 +31,7 @@
         <include>**/*</include>
       </includes>
     </fileSet>
-    
+
     <fileSet>
       <directory>target/i18n</directory>
       <outputDirectory>i18n</outputDirectory>
@@ -40,7 +40,7 @@
       </includes>
     </fileSet>
   </fileSets>
-  
+
   <files>
     <file>
       <source>LICENSE</source>

--- a/pom.xml
+++ b/pom.xml
@@ -1,14 +1,12 @@
 <?xml version="1.0"?>
-<project
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-    xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
     <groupId>com.oxygenxml</groupId>
-    <artifactId>oxygen-plugins-superpom</artifactId>
+    <artifactId>oxygen-superpom-versions</artifactId>
     <!-- IMPORTANT: On branch this should be the latest public version. -->
-    <version>21.1.0.0</version>
+    <version>24.1.0.0</version>
   </parent>
   <artifactId>web-author-rest-plugin-oauth</artifactId>
   <name>Web Author REST plugin - With OAuth</name>
@@ -25,40 +23,40 @@
     <sonar.sources>src/main/java,web</sonar.sources>
   </properties>
 
-    <repositories>
-        <repository>
-            <id>public</id>
-            <name>oXygen public artifacts</name>
-            <url>https://www.oxygenxml.com/maven</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-        <repository>
-            <id>public2</id>
-            <name>Maven Repo</name>
-            <url>https://mvnrepository.com/artifact</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>   
-        <repository>
-            <id>Oxygen_D_Plugin</id>
-            <url>https://ingeniuxdev.pkgs.visualstudio.com/_packaging/Oxygen_D_Plugin/maven/v1</url>
-            <releases>
-                <enabled>true</enabled>
-            </releases>
-            <snapshots>
-                <enabled>true</enabled>
-            </snapshots>
-        </repository>
-    </repositories>  
+  <repositories>
+    <repository>
+      <id>public</id>
+      <name>oXygen public artifacts</name>
+      <url>https://www.oxygenxml.com/maven</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+    <repository>
+      <id>public2</id>
+      <name>Maven Repo</name>
+      <url>https://mvnrepository.com/artifact</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+    <repository>
+      <id>Oxygen_D_Plugin</id>
+      <url>https://ingeniuxdev.pkgs.visualstudio.com/_packaging/Oxygen_D_Plugin/maven/v1</url>
+      <releases>
+        <enabled>true</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
 
   <dependencies>
     <dependency>
@@ -74,12 +72,43 @@
       <version>${project.version}</version>
       <scope>provided</scope>
     </dependency>
-	<!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
-	<dependency>
-		<groupId>com.google.code.gson</groupId>
-		<artifactId>gson</artifactId>
-		<version>2.8.7</version>
-	</dependency>
+    <dependency>
+      <groupId>javax.servlet</groupId>
+      <artifactId>javax.servlet-api</artifactId>
+      <version>3.0.1</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>2.18.0</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-1.2-api</artifactId>
+      <version>2.18.0</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>1.10.19</version>
+      <scope>test</scope>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
+    <dependency>
+      <groupId>com.google.code.gson</groupId>
+      <artifactId>gson</artifactId>
+      <version>2.8.7</version>
+    </dependency>
 
   </dependencies>
 
@@ -143,15 +172,95 @@
           </execution>
         </executions>
       </plugin>
-      
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>set-version-no-snapshot</id>
+            <goals>
+              <goal>regex-property</goal>
+            </goals>
+            <configuration>
+              <name>project.nosnapshot.version</name>
+              <value>${project.version}</value>
+              <regex>-SNAPSHOT</regex>
+              <replacement></replacement>
+              <failIfNoMatch>false</failIfNoMatch>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <!-- We only want the final JAR package in the target folder so that it's easier for users to identify it.-->
+          <outputDirectory>${project.build.directory}/build</outputDirectory>
+        </configuration>
+      </plugin>
+
+      <!-- Download all the dependencies in the target/lib folder. -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>download-deps</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.directory}/lib</outputDirectory>
+              <includeScope>runtime</includeScope>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- Deploy third-party-components.xml artifact-->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>declare-third-party-components-artifact</id>
+            <goals>
+              <goal>attach-artifact</goal>
+            </goals>
+            <configuration>
+              <artifacts>
+                <artifact>
+                  <file>${thirdPartyComponents}</file>
+                  <classifier>third-party-components</classifier>
+                  <type>xml</type>
+                </artifact>
+              </artifacts>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.sonarsource.scanner.maven</groupId>
         <artifactId>sonar-maven-plugin</artifactId>
         <configuration>
           <skip>${sonar.skip.check}</skip>
         </configuration>
-     </plugin>
+      </plugin>
     </plugins>
   </build>
-  
+
 </project>

--- a/src/main/java/com/oxygenxml/rest/plugin/DtdCacheModel.java
+++ b/src/main/java/com/oxygenxml/rest/plugin/DtdCacheModel.java
@@ -1,0 +1,52 @@
+package com.oxygenxml.rest.plugin;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
+import java.time.Instant;
+import java.time.LocalDateTime;
+
+import org.apache.commons.io.IOUtils;
+
+/**
+ *
+ * @author awang
+ */
+public class DtdCacheModel extends DtdModel {
+
+    public byte[] Content;
+
+    public DtdCacheModel(File file) throws FileNotFoundException, IOException {
+        Name = file.getName();
+
+        BasicFileAttributes attr = Files.readAttributes(Paths.get(file.getAbsolutePath()), BasicFileAttributes.class);
+        setLastUpdatedTime(attr.lastModifiedTime());
+
+        System.out.println("Last mod time for " + Name + ":" + getLastUpdatedTime().toString());
+
+        Content = Files.readAllBytes(file.toPath());
+    }
+
+    public DtdCacheModel(DtdModelWithContent d) {
+        Name = d.Name;
+        Id = d.Id;
+        LastUpdated = d.LastUpdated;
+        Content = d.Content.getBytes(StandardCharsets.UTF_8);
+    }
+
+    public DtdCacheModel(String name, InputStream s) throws IOException {
+        Name = name;
+        setLastUpdatedTime(FileTime.from(Instant.now()));
+        Content = IOUtils.toByteArray(s);
+    }
+}
+

--- a/src/main/java/com/oxygenxml/rest/plugin/DtdCacher.java
+++ b/src/main/java/com/oxygenxml/rest/plugin/DtdCacher.java
@@ -1,0 +1,142 @@
+package com.oxygenxml.rest.plugin;
+
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashSet;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.commons.io.IOUtils;
+
+/**
+ *
+ * @author Arnold Wang
+ */
+public class DtdCacher {
+
+    ConcurrentHashMap<String, DtdCacheModel> dtdContents = new ConcurrentHashMap<String, DtdCacheModel>();
+
+    RestURLConnection rest;
+
+    final static String STORAGE_LOCATION = "Oxygen/igx_dtd_cache";
+
+    String storageLocation;
+
+    static volatile DtdCacher instance;
+
+    public static DtdCacher get(RestURLConnection rest) {
+        DtdCacher localRef = instance;
+        if (localRef == null) {
+            synchronized (DtdCacher.class) {
+                localRef = instance;
+                if (localRef == null) {
+                    instance = localRef = new DtdCacher(rest);
+                }
+            }
+        }
+        return localRef;
+    }
+
+    private DtdCacher(RestURLConnection rest) {
+        this.rest = rest;
+
+        //load local files first
+        try {
+            File parent = new File(System.getProperty("user.home"));
+            storageLocation = parent.getAbsolutePath() + "/" + STORAGE_LOCATION;
+            //get the files under this location and push them to cache
+
+            File dtdParent = new File(storageLocation);
+
+            if (!dtdParent.exists()) {
+                dtdParent.mkdirs();
+            } else {
+                for (File f : dtdParent.listFiles()) {
+                    if (f.isFile()) {
+                        DtdCacheModel dtdCacheModel = new DtdCacheModel(f);
+                        dtdContents.put(dtdCacheModel.Name, dtdCacheModel);
+                    }
+                }
+            }
+
+            HashSet<String> idsToUpdate = new HashSet<String>();
+
+            EnvironmentModel env = rest.getEnvironment();
+
+            if (env != null) {
+
+                final DtdModel[] dtds = env.Dtds;
+
+                //check for update
+                for (DtdModel d : dtds) {
+                    if (!dtdContents.containsKey(d.Name)) {
+                        idsToUpdate.add(d.Id);
+                    } else {
+                        DtdCacheModel cacheD = dtdContents.get(d.Name);
+                        if (cacheD.getLastUpdatedTime().compareTo(d.getLastUpdatedTime()) < 0) {
+                            idsToUpdate.add(d.Id);
+                        }
+                    }
+                }
+            }
+            final int idsCount = idsToUpdate.size();
+
+            if (idsCount > 0) {
+                System.out.println("Found " + idsCount + " dtd to update");
+
+                String arr[] = new String[idsToUpdate.size()];
+
+                // toArray() method converts the set to array
+                idsToUpdate.toArray(arr);
+
+                //get dtd updates
+                DtdModelWithContent[] updatedDtdContents = rest.getDtdContents(arr);
+
+                if (updatedDtdContents != null) {
+                    for (DtdModelWithContent d : updatedDtdContents) {
+                        //save to disk first
+                        FileWriter fw = new FileWriter(new File(storageLocation + "/" + d.Name));
+                        fw.write(d.Content);
+                        fw.flush();
+                        fw.close();
+
+                        //add to cache
+                        dtdContents.put(d.Name,
+                                new DtdCacheModel(d));
+
+                        System.out.println("Saved dtd " + d.Name + " to cache");
+                    }
+                }
+            }
+
+        } catch (Exception e) {
+            System.out.println(e);
+        }
+    }
+
+    public InputStream getCache(String name) {
+        if (dtdContents.containsKey(name)) {
+            DtdCacheModel cache = dtdContents.get(name);
+            if (cache != null) {
+                return new ByteArrayInputStream(cache.Content);
+            }
+        }
+
+        return null;
+    }
+
+    public void putCache(String name, InputStream strm) throws IOException {
+        final DtdCacheModel dtdCacheModel = new DtdCacheModel(name, strm);
+        dtdContents.put(name, dtdCacheModel);
+
+        String content = new String(dtdCacheModel.Content, StandardCharsets.UTF_8);
+        FileWriter fw = new FileWriter(new File(storageLocation + "/" + name));
+        fw.write(content);
+        fw.flush();
+        fw.close();
+    }
+}

--- a/src/main/java/com/oxygenxml/rest/plugin/DtdModel.java
+++ b/src/main/java/com/oxygenxml/rest/plugin/DtdModel.java
@@ -1,0 +1,42 @@
+package com.oxygenxml.rest.plugin;
+
+import static com.icl.saxon.exslt.Date.date;
+import java.nio.file.attribute.FileTime;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.time.LocalDateTime;
+
+/**
+ *
+ * @author awang
+ */
+public class DtdModel {
+
+    public String Id;
+    public String Name;
+    public String LastUpdated;
+
+    private FileTime _lastUpdatedTime = null;
+
+    public FileTime getLastUpdatedTime() {
+        if (_lastUpdatedTime == null) {
+            try {
+                int i = LastUpdated.lastIndexOf(".");
+                String ludS = ( i > -1) ? LastUpdated.substring(0, i) : LastUpdated;
+
+                long milis = new SimpleDateFormat("yyyy-MM-dd'T'hh:mm:ss").parse(ludS)
+                        .getTime();
+                _lastUpdatedTime = FileTime.fromMillis(milis);
+            } catch (ParseException e) {
+                // TODO Auto-generated catch block
+                e.printStackTrace();
+            }
+        }
+
+        return _lastUpdatedTime;
+    }
+
+    public void setLastUpdatedTime(FileTime time) {
+        _lastUpdatedTime = time;
+    }
+}

--- a/src/main/java/com/oxygenxml/rest/plugin/DtdModelWithContent.java
+++ b/src/main/java/com/oxygenxml/rest/plugin/DtdModelWithContent.java
@@ -1,0 +1,10 @@
+package com.oxygenxml.rest.plugin;
+
+/**
+ *
+ * @author awang
+ */
+public class DtdModelWithContent extends DtdModel {
+    public String Content;
+}
+

--- a/src/main/java/com/oxygenxml/rest/plugin/EnvironmentModel.java
+++ b/src/main/java/com/oxygenxml/rest/plugin/EnvironmentModel.java
@@ -1,0 +1,14 @@
+package com.oxygenxml.rest.plugin;
+
+/**
+ *
+ * @author awang
+ */
+public class EnvironmentModel {
+
+    public boolean CanAssign;
+    public boolean CanDelete;
+    public boolean CustomTemplatesOnly;
+    public DtdModel[] Dtds;
+
+}

--- a/src/main/java/com/oxygenxml/rest/plugin/RestURLStreamHandler.java
+++ b/src/main/java/com/oxygenxml/rest/plugin/RestURLStreamHandler.java
@@ -20,7 +20,7 @@ import ro.sync.basic.util.URLUtil;
 
 /**
  * URL stream handler for a rest server.
- * 
+ *
  * @author mihai_coanda
  */
 public class RestURLStreamHandler extends URLStreamHandlerWithContext {
@@ -74,11 +74,11 @@ public class RestURLStreamHandler extends URLStreamHandlerWithContext {
 
   /**
    * Computes the new URL to the REST server from the current connection.
-   * 
+   *
    * @param url the current URL.
-   * 
+   *
    * @return the URL to the REST server that represents the current URL.
-   * 
+   *
    * @throws MalformedURLException whether something fails.
    */
   private static URL computeRestUrl(URL url) throws MalformedURLException {
@@ -95,7 +95,7 @@ public class RestURLStreamHandler extends URLStreamHandlerWithContext {
 
   /**
    * Getter for the server's base rest url.
-   * 
+   *
    * @return the server URL.
    */
   public static String getServerUrl() {


### PR DESCRIPTION
This adds a client side DTD caching system.

Most of the new classes are models carried over from the OxygenDesktopPlugin.

The main changes to the existing code are:
- In `RestURLConnector.java`, there's new logic triggered when a requested asset is detected to be DTD
   - A `DtdCacher` object checks whether the requested asset exists in the client side cache (this is two-tiered, both an in-memory cache and a filesystem cache). If this check returns true:
     - A request is made to the server to check whether the requested assets have been updated server side
     - If they have, the filesystem cache and in-memory cache are both updated with the updated assets downloaded from the server
   - Otherwise, the DTD is requested from the server (which has its own caching logic)
- If the requested asset is not detected to be DTD, fallback to existing behavior.

There are also some updates to `pom.xml` and `assembly.xml` to make the plugin and build work with Oxygen Web Author 24